### PR TITLE
[DOCS-3367] Remove `id` and `order` from OrderItems model

### DIFF
--- a/src/main/java/fauna/sample/controllers/orders/Order.java
+++ b/src/main/java/fauna/sample/controllers/orders/Order.java
@@ -42,24 +42,8 @@ public class Order {
 
     public static class Item {
 
-        // Add @FaunaId attribute to indicate that it's an ID on a document. This tells
-        // the codec library to ignore this during encoding.
-        //
-        // To use client-generated IDs, use @FaunaId( isClientGenerate = true), which will
-        // tell the codec library to encode it if it is not null.
-        @FaunaId
-        private String id;
-        private Order order;
         private Product product;
         private Integer quantity;
-
-        public String getId() {
-            return id;
-        }
-
-        public Order getOrder() {
-            return order;
-        }
 
         public Product getProduct() {
             return product;


### PR DESCRIPTION
### Problem

Order response include `id` and `order` fields for each item. These fields aren't retrieved in the underlying FQL query and are always null.

### Solution
Remove the `id` and `order` fields from the `Item` class.
