### PR TITLE
Fix test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,20 +6,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-  services:
-    fauna:
-      image: fauna/faunadb
-      ports:
-        - 8443:8443
-  steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
+    services:
+      fauna:
+        image: fauna/faunadb
+        ports:
+          - 8443:8443
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-    - name: Set up JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: corretto
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: corretto
 
-    - name: Run sample app
-      run: ./gradlew build
+      - name: Run sample app
+        run: ./gradlew build


### PR DESCRIPTION
[DOCS-3788](https://faunadb.atlassian.net/browse/DOCS-3788)

Current YAML indentation causes workflow runs to fail. Ran into this while working on https://github.com/fauna/java-sample-app/pull/24.

[DOCS-3788]: https://faunadb.atlassian.net/browse/DOCS-3788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ